### PR TITLE
Bump V to 0.5.1 and fix CI: download prebuilt binaries instead of building from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout ${{ github.event.repository.name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install V
         uses: vlang/setup-v@v1.4
         with:
-          version: weekly.2025.48
+          version: 0.5.1
 
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,13 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        include:
+          - os: ubuntu-latest
+            v_asset: v_linux.zip
+          - os: macos-latest
+            v_asset: v_macos_arm64.zip
+          - os: windows-latest
+            v_asset: v_windows.zip
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout ${{ github.event.repository.name }}
@@ -18,49 +24,26 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Diagnostic info (macOS runner)
-        if: matrix.os == 'macos-latest'
+      - name: Install V (Linux/macOS)
+        if: runner.os != 'Windows'
         shell: bash
         run: |
-          echo "runner.os=${{ runner.os }}"
-          echo "runner.arch=${{ runner.arch }}"
-          echo "image.os=${ImageOS:-unknown}"
-          echo "image.version=${ImageVersion:-unknown}"
-          uname -a || true
-          sw_vers || true
-          env | sort
+          curl -fsSL "https://github.com/vlang/v/releases/download/0.5.1/${{ matrix.v_asset }}" -o v.zip
+          unzip -q v.zip
+          echo "$PWD/v" >> "$GITHUB_PATH"
+          ./v/v version
 
-      - name: Install V
-        id: install_v
-        uses: vlang/setup-v@v1.4
-        continue-on-error: ${{ matrix.os == 'macos-latest' }}
-        with:
-          version: 0.5.1
-
-      - name: Diagnostic info (after setup-v)
-        if: always() && matrix.os == 'macos-latest'
-        shell: bash
+      - name: Install V (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
         run: |
-          echo "setup-v outcome: ${{ steps.install_v.outcome }}"
-          echo "setup-v conclusion: ${{ steps.install_v.conclusion }}"
-          command -v v || true
-          v version || true
-          v -version || true
-          ls -la "$GITHUB_WORKSPACE" || true
-          ls -la "$GITHUB_WORKSPACE/vlang" || true
-
-      - name: Fallback V bootstrap from source (macOS)
-        if: matrix.os == 'macos-latest' && steps.install_v.outcome == 'failure'
-        shell: bash
-        run: |
-          set -euxo pipefail
-          git clone --depth 1 --branch 0.5.1 https://github.com/vlang/v "$GITHUB_WORKSPACE/vlang-fallback"
-          make -C "$GITHUB_WORKSPACE/vlang-fallback"
-          echo "$GITHUB_WORKSPACE/vlang-fallback" >> "$GITHUB_PATH"
-          "$GITHUB_WORKSPACE/vlang-fallback/v" version
+          Invoke-WebRequest -Uri "https://github.com/vlang/v/releases/download/0.5.1/${{ matrix.v_asset }}" -OutFile v.zip
+          Expand-Archive -Path v.zip -DestinationPath .
+          echo "$PWD\v" | Out-File -Append -Encoding utf8 $env:GITHUB_PATH
+          .\v\v.exe version
 
       - name: Build ${{ github.event.repository.name }}
         run: v -prod -gc none compiler.v
-        
+
       - name: Run Tests
         run: v -stats test modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,51 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install V
-        uses: vlang/setup-v@v1.4
-        with:
-          version: 0.5.1
-
       - name: Checkout ${{ github.event.repository.name }}
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Diagnostic info (macOS runner)
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          echo "runner.os=${{ runner.os }}"
+          echo "runner.arch=${{ runner.arch }}"
+          echo "image.os=${ImageOS:-unknown}"
+          echo "image.version=${ImageVersion:-unknown}"
+          uname -a || true
+          sw_vers || true
+          env | sort
+
+      - name: Install V
+        id: install_v
+        uses: vlang/setup-v@v1.4
+        continue-on-error: ${{ matrix.os == 'macos-latest' }}
+        with:
+          version: 0.5.1
+
+      - name: Diagnostic info (after setup-v)
+        if: always() && matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          echo "setup-v outcome: ${{ steps.install_v.outcome }}"
+          echo "setup-v conclusion: ${{ steps.install_v.conclusion }}"
+          command -v v || true
+          v version || true
+          v -version || true
+          ls -la "$GITHUB_WORKSPACE" || true
+          ls -la "$GITHUB_WORKSPACE/vlang" || true
+
+      - name: Fallback V bootstrap from source (macOS)
+        if: matrix.os == 'macos-latest' && steps.install_v.outcome == 'failure'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          git clone --depth 1 --branch 0.5.1 https://github.com/vlang/v "$GITHUB_WORKSPACE/vlang-fallback"
+          make -C "$GITHUB_WORKSPACE/vlang-fallback"
+          echo "$GITHUB_WORKSPACE/vlang-fallback" >> "$GITHUB_PATH"
+          "$GITHUB_WORKSPACE/vlang-fallback/v" version
 
       - name: Build ${{ github.event.repository.name }}
         run: v -prod -gc none compiler.v

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install V
         uses: vlang/setup-v@v1.4
         with:
-          version: weekly.2025.48
+          version: 0.5.1
      
       - name: Build Project
         run: v -prod -g -gc none -o "bin/papyrus-compiler" compiler.v

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -34,22 +34,38 @@ jobs:
         include:
           - os: windows-latest
             artifact: papyrus-compiler-windows.zip
+            v_asset: v_windows.zip
           - os: ubuntu-latest
             artifact: papyrus-compiler-ubuntu.tar.gz
+            v_asset: v_linux.zip
           - os: macos-latest
             artifact: papyrus-compiler-macos.tar.gz
+            v_asset: v_macos_arm64.zip
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           submodules: recursive
-  
-      - name: Install V
-        uses: vlang/setup-v@v1.4
-        with:
-          version: 0.5.1
-     
+
+      - name: Install V (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          curl -fsSL "https://github.com/vlang/v/releases/download/0.5.1/${{ matrix.v_asset }}" -o v.zip
+          unzip -q v.zip
+          echo "$PWD/v" >> "$GITHUB_PATH"
+          ./v/v version
+
+      - name: Install V (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/vlang/v/releases/download/0.5.1/${{ matrix.v_asset }}" -OutFile v.zip
+          Expand-Archive -Path v.zip -DestinationPath .
+          echo "$PWD\v" | Out-File -Append -Encoding utf8 $env:GITHUB_PATH
+          .\v\v.exe version
+
       - name: Build Project
         run: v -prod -g -gc none -o "bin/papyrus-compiler" compiler.v
       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ### New Features
 
 - Added support for multiple output directories - you can now specify multiple `-o` flags to copy compiled .pex files to multiple locations. #18
+- Added Nix flake (`flake.nix`) — the compiler can now be built and run as a Nix package. #15
+
+### Improvements
+
+- Updated required V compiler version to [0.5.1](https://github.com/vlang/v/releases/tag/0.5.1) (previously `weekly.2025.48`).
+
+### CI/CD
+
+- Fixed CI pipeline on all platforms: replaced `vlang/setup-v` (which fell back to building V from source and failed due to a bootstrap compiler incompatibility with `$if native` in V 0.5.x) with a direct download of prebuilt release binaries from GitHub Releases.
+- Updated `actions/checkout` from v4 to v6 (Node.js 24).
 
 ...
 

--- a/README.RU.md
+++ b/README.RU.md
@@ -130,7 +130,7 @@ Function EquipItem(Form akItem, bool abPreventRemoval = false, bool abSilent = f
 ## Сборка
 
 ### Требования:
-- [V compiler d0dc13e (weekly.2025.48)](https://github.com/vlang/v/releases/tag/weekly.2025.48)
+- [V compiler 0c3183c (0.5.1)](https://github.com/vlang/v/releases/tag/0.5.1)
 
 ```bash
 v -o "bin\papyrus-compiler.exe" -prod -g -gc none compiler.v

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Scripts from the directory specified by the `-h "..."` argument will NOT be comp
 ## Building
 
 ### Requirements:
-- [V compiler d0dc13e (weekly.2025.48)](https://github.com/vlang/v/releases/tag/weekly.2025.48)
+- [V compiler 0c3183c (0.5.1)](https://github.com/vlang/v/releases/tag/0.5.1)
 
 ```bash
 v -o "bin\papyrus-compiler.exe" -prod -g -gc none compiler.v


### PR DESCRIPTION
Pin V compiler to 0.5.1 in CI and manual-release workflows (replace weekly.2025.48). Update README.md and README.RU.md build requirement links to reference the 0.5.1 release.